### PR TITLE
1.2.0 Remove marketplace standard until it is compatible with PHPCS3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,15 @@
 # Introduction
 
-This is the MediaCT coding standard for Magento 1 projects. It is a mix of the
-default MediaCT coding standard and the Magento marketplace standard.
-
-Some tests have been removed from both of the standards to create a workable
-and fast standard.
+This is the MediaCT coding standard for Magento 1 projects. It is based on 
+the default MediaCT coding standard but some tests have been removed to create
+a workable and fast standard.
 
 # Installation
 
 Use composer to require the standard in a project.
 
 ```shell
-$ composer require --dev mediact/coding-standard-magento1
+composer require --dev mediact/coding-standard-magento1
 ```
 
 To let PHPCS know that this standard should be used add a phpcs.xml file in the
@@ -30,7 +28,7 @@ The recommended way to enable the coding standard in PHPStorm and automatic
 testing is by requiring the MediaCT testing suite in a project.
 
 ```shell
-$ composer require --dev mediact/testing-suite
+composer require --dev mediact/testing-suite
 ```
 
 For more information go to [MediaCT Testing Suite](https://github.com/mediact/testing-suite).

--- a/composer.json
+++ b/composer.json
@@ -10,18 +10,7 @@
             "email": "contact@mediact.nl"
         }
     ],
-    "repositories": [
-        {
-            "type": "composer",
-            "url": "https://composer.mediact.nl"
-        },
-        {
-            "type": "composer",
-            "url": "https://repo.magento.com"
-        }
-    ],
     "require": {
-        "magento/marketplace-eqp": "^1.0",
         "mediact/coding-standard": "@stable"
     }
 }

--- a/src/MediactMagento1/ruleset.xml
+++ b/src/MediactMagento1/ruleset.xml
@@ -27,35 +27,11 @@
         <exclude name="Generic.PHP.Syntax"/>
     </rule>
 
-    <!-- Base rules on Magento Marketplace -->
-    <rule ref="../../../../magento/marketplace-eqp/MEQP1">
-        <exclude name="PSR1.Classes.ClassDeclaration" />
-        <exclude name="Zend.NamingConventions.ValidVariableName.PrivateNoUnderscore"/>
-        <exclude name="Generic.Arrays.DisallowShortArraySyntax" />
-        <exclude name="MEQP1.PHP.PrivateClassMember" />
-        <exclude name="MEQP1.Security.DiscouragedFunction" />
-        <exclude name="MEQP1.Performance.Loop" />
-        <exclude name="MEQP1.SQL.SlowQuery" />
-        <exclude name="Generic.Functions.OpeningFunctionBraceBsdAllman" />
-        <exclude name="MEQP1.Performance.CollectionCount"/>
-        <exclude name="PEAR.Functions.FunctionCallSignature.SpaceAfterOpenBracket"/>
-        <exclude name="MEQP1.PHP.Syntax"/>
-        <exclude name="MEQP1.Stdlib.DateTime"/>
-    </rule>
-
-    <rule ref="MEQP1.Classes.ResourceModel.OutsideOfResourceModel">
-        <exclude-pattern>Model/Resource</exclude-pattern>
-    </rule>
     <rule ref="MediactCommon.NamingConventions.ValidVariableName">
         <properties>
             <property name="allowedNames" type="array" value="_eventPrefix,_eventObject,_cacheTag,_addButtonLabel,_backButtonLabel,_blockGroup,_GET,_POST,_COOKIE,_FILES,_REQUEST,_SERVER,_SESSION"/>
         </properties>
         <exclude-pattern>*.phtml</exclude-pattern>
-    </rule>
-    <rule ref="Squiz.PHP.CommentedOutCode">
-        <properties>
-            <property name="maxPercentage" value="80"/>
-        </properties>
     </rule>
     <rule ref="Zend.NamingConventions.ValidVariableName.NotCamelCaps">
         <exclude-pattern>*.phtml</exclude-pattern>


### PR DESCRIPTION
The marketplace coding standard has been modified to be compatible with PHPCS3 but those changes have not yet been released. Therefore they can not be included in the standard.